### PR TITLE
Update ethics policy keys and add forbidden byte test

### DIFF
--- a/config/ethics_policy.json
+++ b/config/ethics_policy.json
@@ -1,6 +1,6 @@
 {
-  "forbid_bytes": [0, 3, 4, 26, 127],
-  "max_repeat": 6,
-  "max_loss": 12.0,
+  "forbidden_bytes": [0, 3, 4, 26, 127],
+  "forbidden_substrings": ["BADWORD"],
+  "max_step_loss": 12.0,
   "abort_on_violation": true
 }

--- a/tests/test_ethics.py
+++ b/tests/test_ethics.py
@@ -1,29 +1,43 @@
 # tests/test_ethics.py
 import sys, json, numpy as np
 from pathlib import Path
+
 sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 from src.train import load_cfg
 from src.controller import Controller
 from src.model import TinyByteLM
-def test_ethics_guard():
-    with open("config/ethics_policy.json","r",encoding="utf-8") as f:
-        pol=json.load(f)
-    cfg=load_cfg(); cfg["seed_base"]=1337
-    ctrl = Controller(cfg, pol, d=cfg["hidden"])
-    model = TinyByteLM(d=cfg["hidden"], k=cfg["value_dim"], seed=1337)
-    # craft x containing forbidden substring
-    x = np.tile(np.frombuffer(b"BADWORD",dtype=np.uint8), (1,cfg["context"]))
-    y = np.array([0])
+
+
+def make_ctrl_and_model():
+    with open("config/ethics_policy.json", "r", encoding="utf-8") as f:
+        policy = json.load(f)
+    cfg = load_cfg(); cfg["seed_base"] = 1337
+    ctrl = Controller(cfg, policy, d=cfg["hidden_dim"])
+    model = TinyByteLM(ctx=cfg["context_len"], d=cfg["hidden_dim"], seed=1337)
+    return cfg, policy, ctrl, model
+
+
+def test_ethics_guard_forbidden_substring():
+    cfg, policy, ctrl, model = make_ctrl_and_model()
+    forbidden = policy["forbidden_substrings"][0]
+    x = np.tile(np.frombuffer(forbidden.encode("latin1"), dtype=np.uint8), (1, cfg["context_len"]))
+    y = np.array([[0]], dtype=np.int64)
     stat = ctrl.step(model, x, y, t=25, warmup=20, last_tokens=x[0])
-    if not stat["abort"]:
-        print("FAIL: ethics violation did not abort"); sys.exit(1)
-    # certificate must invalidate
+    assert stat["abort"], "ethics violation did not abort"
     from src.presence import presence_certificate
-    E=[1.0]*10; rc=[0.0,0.1]+[0.1]*8
-    pres, cert = presence_certificate({"E":E,"rc":rc,"ups_rate":0.1}, cfg, ethics_viol=1, delta_xi=0.0)
-    if cert["presence"]:
-        print("FAIL: presence should be false when ethics violated"); sys.exit(1)
-    print("PASS")
-if __name__=="__main__":
-    test_ethics_guard()
-    print("PASS")
+    E = [1.0] * 10; rc = [0.0, 0.1] + [0.1] * 8
+    pres, cert = presence_certificate({"E": E, "rc": rc, "ups_rate": 0.1}, cfg, ethics_viol=1, xi_hist=[0.0])
+    assert cert["presence"] == "INVALID", "presence should be invalid when ethics violated"
+
+
+def test_forbidden_byte_triggers_violation():
+    cfg, policy, ctrl, model = make_ctrl_and_model()
+    forbidden = policy["forbidden_bytes"][0]
+    model.b2[:] = -1e9
+    model.b2[forbidden] = 1e9
+    x = np.zeros((1, cfg["context_len"]), dtype=np.uint8)
+    y = np.array([[0]], dtype=np.int64)
+    stat = ctrl.step(model, x, y, t=0, warmup=0, last_tokens=x[0])
+    assert stat["abort"], "forbidden byte did not trigger abort"
+


### PR DESCRIPTION
## Summary
- Rename ethics policy config keys to `forbidden_bytes`, `forbidden_substrings`, and `max_step_loss`
- Extend ethics tests with coverage for forbidden substrings and regression for forbidden byte violations

## Testing
- `pytest tests/test_ethics.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb0fa68600832bac1bde0a5cf734cb