### PR TITLE
Make src a package and clean up imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ Set-ExecutionPolicy -Scope Process Bypass
 .\scripts\setup.ps1
 ```
 
+## Installation
+Install the project in editable mode to make the `src` package available:
+
+```bash
+pip install -e .
+```
+
 ## Run tests
 ```powershell
 .\scripts\run_tests.ps1
@@ -23,4 +30,5 @@ Set-ExecutionPolicy -Scope Process Bypass
 ## Outputs
 * Per run: `logs\metrics.csv`, `logs\shadow_codex.jsonl`
 * A/B summary: `logs\ab_summary.json`
-* Presence certificate (ON runs): `presence.json`# koriel-asi-project
+* Presence certificate (ON runs): `presence.json`
+

--- a/scripts/sample_with_rcce.py
+++ b/scripts/sample_with_rcce.py
@@ -4,17 +4,13 @@ Sample from trained byte-LM with RCCE modulation active.
 """
 import argparse
 import os
-import sys
 import torch
 import pandas as pd
 from rich.console import Console
 from rich.table import Table
 
-# Add src to path
-sys.path.append(os.path.join(os.path.dirname(os.path.dirname(__file__)), 'src'))
-
-from byte_lm.model import TinyByteTransformer
-from byte_lm.generate import generate_with_rcce, tokens_to_text
+from src.byte_lm.model import TinyByteTransformer
+from src.byte_lm.generate import generate_with_rcce, tokens_to_text
 
 def main():
     parser = argparse.ArgumentParser(description='Sample from tiny byte-LM with RCCE')

--- a/scripts/train_tiny_lm.py
+++ b/scripts/train_tiny_lm.py
@@ -4,16 +4,12 @@ Train tiny byte-LM with RCCE controller integration.
 """
 import argparse
 import os
-import sys
 import torch
 
-# Add src to path
-sys.path.append(os.path.join(os.path.dirname(os.path.dirname(__file__)), 'src'))
-
-from byte_lm.data import get_dataset
-from byte_lm.model import TinyByteTransformer, count_parameters
-from byte_lm.train import train_one_epoch
-from rcc.controller import init_rcce_state
+from src.byte_lm.data import get_dataset
+from src.byte_lm.model import TinyByteTransformer, count_parameters
+from src.byte_lm.train import train_one_epoch
+from src.rcc.controller import init_rcce_state
 
 def main():
     parser = argparse.ArgumentParser(description='Train tiny byte-LM with RCCE')

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,2 @@
+"""Koriel ASI core package."""
+

--- a/tests/test_ab.py
+++ b/tests/test_ab.py
@@ -1,7 +1,6 @@
 # tests/test_ab.py
 import sys, json
 from pathlib import Path
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 from src.ab import main
 def test_ab():
     main()

--- a/tests/test_certificates.py
+++ b/tests/test_certificates.py
@@ -1,7 +1,5 @@
 # tests/test_certificate.py
 import sys, numpy as np
-from pathlib import Path
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 from src.presence import presence_certificate
 from src.train import load_cfg
 def test_certificate():

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,7 +1,5 @@
 # tests/test_dec.py
 import sys, numpy as np
-from pathlib import Path
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 from src.dec import d_0_to_1, d_1_to_2, d2_norm, torsion_curvature
 def test_dec_identities():
     f0 = np.linspace(0,1,33)

--- a/tests/test_ethics.py
+++ b/tests/test_ethics.py
@@ -1,7 +1,5 @@
 # tests/test_ethics.py
 import sys, json, numpy as np
-from pathlib import Path
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 from src.train import load_cfg
 from src.controller import Controller
 from src.model import TinyByteLM

--- a/tests/test_lambda_plus.py
+++ b/tests/test_lambda_plus.py
@@ -1,27 +1,35 @@
+# tests/test_lambda_plus.py
 import sys, numpy as np
-from pathlib import Path
-sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 from src.train import run
 
+
 def slope(y):
-    n=len(y); x=np.arange(n); xb=x.mean(); yb=np.mean(y)
-    num=((x-xb)*(y-yb)).sum(); den=((x-xb)**2).sum()+1e-12
-    return float(num/den)
+    n = len(y)
+    x = np.arange(n)
+    xb = x.mean()
+    yb = np.mean(y)
+    num = ((x - xb) * (y - yb)).sum()
+    den = ((x - xb) ** 2).sum() + 1e-12
+    return float(num / den)
+
 
 def main():
-    m_on_plus,_  = run(seed=1340, rcce_on=True, out_prefix="LPLUS_ON",  lambda_plus=True)
-    m_on_skip,_  = run(seed=1340, rcce_on=True, out_prefix="LPLUS_OFF", lambda_plus=False)
+    m_on_plus, _ = run(seed=1340, rcce_on=True, out_prefix="LPLUS_ON", lambda_plus=True)
+    m_on_skip, _ = run(seed=1340, rcce_on=True, out_prefix="LPLUS_OFF", lambda_plus=False)
     # energy rebound higher when skipping Λ⁺
-    E_tail_on  = np.mean(m_on_plus["E"][-10:])
+    E_tail_on = np.mean(m_on_plus["E"][-10:])
     E_tail_off = np.mean(m_on_skip["E"][-10:])
     if not (E_tail_off > E_tail_on):
         print("FAIL: Lambda+ skip did not increase energy rebound"); sys.exit(1)
     # RC drop worse when skipping Lambda+
-    s_on  = slope(m_on_plus["rc"])
+    s_on = slope(m_on_plus["rc"])
     s_off = slope(m_on_skip["rc"])
     if not (s_on > s_off):
         print("FAIL: Lambda+ skip did not worsen RC slope"); sys.exit(1)
     print("PASS")
 
-if __name__=="__main__":
+
+if __name__ == "__main__":
     main()
+

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,7 +1,5 @@
 # tests/test_metrics.py
 import sys, json, numpy as np
-from pathlib import Path
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 from src.train import run
 def assert_close(a,b,eps,message):
     if not (a>=b):  # for monotone improvements we use >=


### PR DESCRIPTION
## Summary
- add empty package marker in `src`
- stop mutating `sys.path` in tests and scripts and import from the package
- document editable install for importing the package

## Testing
- `PYTHONPATH=. pytest tests -q` *(fails: ImportError: cannot import name 'd_0_to_1' from 'src.dec')*


------
https://chatgpt.com/codex/tasks/task_e_68bb0fa73e3c832b990b95eefa52472b