### PR TITLE
Package src modules and remove sys.path hacks from tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,5 +112,8 @@ __pycache__/
 data/processed/*
 */.ipynb_checkpoints/*
 
+# Packaging artifacts
+*.egg-info/
+
 # Auto-mesh artifacts
 ops/ingest/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,9 @@
+from setuptools import setup
+
+
+setup(
+    name="koriel",
+    version="0.1.0",
+    packages=["src", "src.byte_lm", "src.rcc"],
+)
+

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,12 @@
+"""Top-level package for the Koriel ASI project.
+
+This file allows the modules located in ``src/`` to be imported as a
+package after installation (e.g. ``from src import ab``).
+"""
+
+# Package exports are intentionally minimal to avoid importing heavy
+# dependencies at module import time. Submodules can be imported as
+# ``from src import ab`` or ``from src import rcc`` after installation.
+
+__all__: list[str] = []
+

--- a/src/rcc/__init__.py
+++ b/src/rcc/__init__.py
@@ -1,0 +1,12 @@
+"""RCCE (Recursive Coherence and Consciousness Engine) package."""
+
+from .controller import compute_rcce_metrics, ethical_guard  # noqa: F401
+from .observer import ObserverState, control_step  # noqa: F401
+
+__all__ = [
+    "compute_rcce_metrics",
+    "ethical_guard",
+    "ObserverState",
+    "control_step",
+]
+

--- a/tests/test_ab.py
+++ b/tests/test_ab.py
@@ -1,7 +1,6 @@
 # tests/test_ab.py
 import sys, json
 from pathlib import Path
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 from src.ab import main
 def test_ab():
     main()

--- a/tests/test_certificates.py
+++ b/tests/test_certificates.py
@@ -1,7 +1,5 @@
 # tests/test_certificate.py
 import sys, numpy as np
-from pathlib import Path
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 from src.presence import presence_certificate
 from src.train import load_cfg
 def test_certificate():

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1,6 +1,3 @@
-import os, sys
-from pathlib import Path
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 from src.data import load_corpus
 
 

--- a/tests/test_dec.py
+++ b/tests/test_dec.py
@@ -1,7 +1,5 @@
 # tests/test_dec.py
 import sys, numpy as np
-from pathlib import Path
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 from src.dec import (
     incidence_0_to_1,
     incidence_1_to_2,

--- a/tests/test_ethics.py
+++ b/tests/test_ethics.py
@@ -1,9 +1,4 @@
 # tests/test_ethics.py
-import sys, json, numpy as np
-from pathlib import Path
-
-sys.path.append(str(Path(__file__).resolve().parents[1]))
-
 from src.train import load_cfg
 from src.controller import Controller
 from src.model import TinyByteLM

--- a/tests/test_lambda_plus.py
+++ b/tests/test_lambda_plus.py
@@ -1,6 +1,4 @@
 import sys, numpy as np
-from pathlib import Path
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 from src.train import run
 
 def slope(y):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,7 +1,5 @@
 # tests/test_metrics.py
 import sys, json, numpy as np
-from pathlib import Path
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 from src.train import run
 
 def slope(y):


### PR DESCRIPTION
## Summary
- add `__init__.py` files to treat `src/` and `src/rcc/` as packages
- include minimal `setup.py` & `pyproject.toml` for editable installs
- simplify tests to import the package directly without path tweaks

## Testing
- `python tests/test_dec.py`
- `python tests/test_ab.py` *(fails: IndentationError in src/train.py)*
- `python tests/test_ethics.py` *(fails: IndentationError in src/train.py)*
- `python tests/test_metrics.py` *(fails: IndentationError in src/train.py)*
- `python tests/test_lambda_plus.py` *(fails: IndentationError in src/train.py)*
- `python tests/test_certificates.py` *(fails: IndentationError in src/train.py)*
- `python tests/test_data_loader.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb16010834832b8c64aedf3e2aa3ec

## Summary by Sourcery

Package the src modules with __init__.py and enable editable installations via setup.py and pyproject.toml, then simplify tests by removing sys.path hacks and using direct package imports

Enhancements:
- Add __init__.py files to make src and src/rcc importable as packages
- Simplify tests by removing sys.path hacks and importing the package directly

Build:
- Add setup.py and pyproject.toml to support editable installs

Tests:
- Remove manual path manipulation from test modules