### PR TITLE
Vectorize embedding gradient update in TinyByteLM

### DIFF
--- a/src/model.py
+++ b/src/model.py
@@ -69,10 +69,9 @@ class TinyByteLM:
         db1 = dh.sum(axis=0)  # [d]
         
         dE = np.zeros_like(self.E)
-        for b in range(B):
-            idxs = self._x_cache[b]
-            g = dh[b]/max(1, len(idxs))  # [d]
-            dE[idxs] += g
+        seq_len = max(1, self._x_cache.shape[1])
+        g = dh / seq_len  # [B, d]
+        np.add.at(dE, self._x_cache, g[:, None, :])
             
         self.W2 -= lr * dW2; self.b2 -= lr * db2
         self.W1 -= lr * dW1; self.b1 -= lr * db1


### PR DESCRIPTION
## Summary
- Replace per-example embedding gradient loop with vectorized `np.add.at` implementation.
- Preserve original normalization by sequence length.

## Testing
- `pytest tests/test_data_loader.py -q`
- `pytest tests/test_ethics.py -q` *(fails: IndentationError in `src/train.py`)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1601e078832b885291dbf76637ec