### PR TITLE
Implement retrieval handling in agent core

### DIFF
--- a/tests/test_retrieval.py
+++ b/tests/test_retrieval.py
@@ -1,0 +1,34 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from src.qrft_agent_core import QRFTAgent
+
+
+def test_retrieve_success():
+    agent = QRFTAgent()
+    agent.state.current_query = "autopoiesis"
+    response = agent._execute_action("retrieve", agent.state.current_query)
+    assert "autopoiesis maintains organization" in response
+    assert any(f.predicate == "retrieved_info" for f in agent.state.facts)
+
+
+def test_retrieve_failure_no_result():
+    agent = QRFTAgent()
+    agent.state.current_query = "nonexistent topic"
+    response = agent._execute_action("retrieve", agent.state.current_query)
+    assert "Insufficient evidence for" in response
+    assert any(g.gap_type == "retrieval_failure" for g in agent.state.gaps)
+
+
+def test_retrieve_failure_error(monkeypatch):
+    agent = QRFTAgent()
+
+    def boom(query: str):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(agent, "_search_corpus", boom)
+    agent.state.current_query = "anything"
+    response = agent._execute_action("retrieve", agent.state.current_query)
+    assert "Retrieval error" in response
+    assert any(g.gap_type == "retrieval_error" for g in agent.state.gaps)


### PR DESCRIPTION
## Summary
- implement corpus-based retrieval in `_execute_action` with fact storage, gap tracking, and error handling
- add cached corpus loading helper
- add unit tests for retrieval success, missing results, and error paths

## Testing
- `pytest tests/test_retrieval.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sympy'; IndentationError in train.py)*

------
https://chatgpt.com/codex/tasks/task_e_68bb16051bac832bb624afc603ab5973

## Summary by Sourcery

Implement corpus-based retrieval in agent core with caching, fact and gap handling, and add unit tests

New Features:
- Add actual retrieval logic in _execute_action for 'retrieve' action, storing facts on success and tracking gaps on failure or error
- Introduce _search_corpus helper that loads and caches a fallback corpus and searches it by query

Enhancements:
- Cache loaded corpus in QRFTAgent to avoid repeated loading

Tests:
- Add unit tests for retrieval success, retrieval failure with no results, and retrieval error scenarios