### PR TITLE
chore: clarify node_modules ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Dependencies
+# Node.js dependencies
 node_modules/
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
## Summary
- clarify `.gitignore` to explicitly mark `node_modules/` as Node.js dependencies

## Testing
- `npm test` *(fails: No tests found, exiting with code 1)*
- `make test` *(fails: IndentationError in src/train.py)*

------
https://chatgpt.com/codex/tasks/task_e_68bb38dc0190832b88c564522cf802a2

## Summary by Sourcery

Chores:
- Add explicit node_modules/ entry to .gitignore as Node.js dependencies