### PR TITLE
Add pre-commit hooks and contributor documentation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        args: ["--profile=black"]
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8
+        additional_dependencies: ["flake8-bugbear"]
+        args: ["--max-line-length=88", "--extend-ignore=E203,E501,W503"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,26 @@ Thank you for your interest in improving this project!
 - Follow [PEP 8](https://www.python.org/dev/peps/pep-0008/) style guidelines.
 - Use clear naming and add docstrings for public functions and classes.
 
+## Pre-commit hooks
+- Install the formatting and linting hooks:
+
+  ```bash
+  pip install pre-commit
+  pre-commit install
+  ```
+
+- Run the hooks on changed files before committing:
+
+  ```bash
+  pre-commit run --files <file1> [<file2> ...]
+  ```
+
+  To check the entire codebase, use:
+
+  ```bash
+  pre-commit run --all-files
+  ```
+
 ## Testing
 - Add unit tests for new features in the `tests/` directory.
 - Before submitting a pull request run:


### PR DESCRIPTION
## Summary
- configure `pre-commit` with `black`, `isort`, and `flake8`
- document how to install and run pre-commit hooks in CONTRIBUTING guidelines

## Testing
- `pre-commit run --files .pre-commit-config.yaml CONTRIBUTING.md`
- `python -m py_compile $(git ls-files '*.py' | grep -v 'conversations-pocket/rcc_engine.py' | grep -v 'src/train.py')`
- `pytest tests` *(fails: ModuleNotFoundError: No module named 'src')*


------
https://chatgpt.com/codex/tasks/task_e_68bb38e1c7f4832b9adebfd320facb25

## Summary by Sourcery

Configure pre-commit hooks for consistent code formatting and linting, and update contributor guidelines with instructions on installing and running these hooks

New Features:
- Add .pre-commit-config.yaml with Black, isort, and Flake8 hooks

Documentation:
- Document pre-commit installation and usage in CONTRIBUTING.md