### PR TITLE
Add CI workflow for Python and Node tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,3 +2,28 @@ name: CI
 
 on:
   push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Install Node dependencies
+        run: npm install
+      - name: Run Python tests
+        run: pytest
+      - name: Run Node tests
+        run: npm test


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow running pytest and npm test on push and pull_request

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb38e5dc64832b9107edddb9402022