### PR TITLE
Refactor training entry point and fix stress-test imports

### DIFF
--- a/src/stress_test.py
+++ b/src/stress_test.py
@@ -3,9 +3,9 @@ import numpy as np
 import time
 import json
 from pathlib import Path
-from data import load_corpus, make_stream, bigram_features
-from model import TinyByteLM
-from dec import d2_norm, torsion_norm, curvature_comm_norm
+from .data import load_corpus, make_stream, bigram_features
+from .model import TinyByteLM
+from .dec import d2_norm, torsion_norm, curvature_comm_norm
 
 class AdaptiveStressTester:
     def __init__(self, base_config):

--- a/src/train.py
+++ b/src/train.py
@@ -1,92 +1,203 @@
-# src/train.py
-import os, csv, json, math, numpy as np
+"""Training entry point for TinyByteLM with RCCE controller support.
+
+This module separates configuration loading, training logic and CLI
+handling.  The previous version mixed these concerns and ended with an
+incomplete ``if __name__ == "__main__":`` block that caused an
+``IndentationError`` during import.  The refactored structure keeps the
+code importable for the test-suite while still providing a usable command
+line interface.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import math
 from pathlib import Path
+from typing import Optional, Tuple
+
+import numpy as np
 from tqdm import tqdm
-from .data import load_corpus, make_stream
-from .model import TinyByteLM
+
 from .controller import Controller
+from .data import load_corpus, make_stream
 from .metastate import ShadowCodex
+from .model import TinyByteLM
 from .presence import presence_certificate
-def load_cfg():
+
+
+def load_cfg(path: str = "config/rcce.yaml") -> dict:
+    """Load YAML configuration for training.
+
+    Parameters
+    ----------
+    path:
+        Path to the YAML configuration file.
+    """
+
     import yaml
-    with open("config/rcce.yaml","r",encoding="utf-8") as f:
+
+    with open(path, "r", encoding="utf-8") as f:
         return yaml.safe_load(f)
-    import yaml
-    cfg = load_cfg(); cfg["seed_base"]=seed
+
+
+def run(
+    *,
+    seed: int = 1337,
+    rcce_on: bool = True,
+    out_prefix: str = "RUN",
+    corpus_dir: Optional[str] = None,
+    dataset: Optional[str] = None,
+    lambda_plus: bool = False,
+    return_model: bool = False,
+) -> Tuple[dict, float, Optional[TinyByteLM]]:
+    """Execute a training run.
+
+    Parameters mirror the previous behaviour but are now explicit
+    arguments.  The function returns collected metrics, the Upsilon firing
+    rate and optionally the trained model.
+    """
+
+    cfg = load_cfg()
+    cfg["seed_base"] = seed
     np.random.seed(seed)
-    logs_dir = Path("logs"); logs_dir.mkdir(exist_ok=True)
-    sc = ShadowCodex(logs_dir/f"shadow_codex_{out_prefix}_{seed}.jsonl")
-    with open("config/ethics_policy.json","r",encoding="utf-8") as f:
-        policy=json.load(f)
-    data = load_corpus("conversations-pocket" if corpus_dir is None else corpus_dir, dataset=dataset)
-    ctx = cfg["context_len"]; batch = cfg["batch_size"]; steps = cfg["steps"]; warm = cfg["warmup"]
+
+    logs_dir = Path("logs")
+    logs_dir.mkdir(exist_ok=True)
+    sc = ShadowCodex(logs_dir / f"shadow_codex_{out_prefix}_{seed}.jsonl")
+
+    with open("config/ethics_policy.json", "r", encoding="utf-8") as f:
+        policy = json.load(f)
+
+    data = load_corpus(
+        "conversations-pocket" if corpus_dir is None else corpus_dir,
+        dataset=dataset,
+    )
+
+    ctx = cfg["context_len"]
+    steps = cfg["steps"]
+    warm = cfg["warmup"]
+
     model = TinyByteLM(ctx=ctx, d=cfg["hidden_dim"], seed=seed)
     ctrl = Controller(cfg, policy, d=cfg["hidden_dim"])
     ctrl.lambda_plus_enabled = bool(lambda_plus)
-    metrics = {"t":[], "loss":[], "rc":[], "D":[], "dD":[], "E":[], "ups":[], "T":[], "R":[]}
+
+    metrics = {
+        "t": [],
+        "loss": [],
+        "rc": [],
+        "D": [],
+        "dD": [],
+        "E": [],
+        "ups": [],
+        "T": [],
+        "R": [],
+    }
+
     last_tokens = np.concatenate(data)[:ctx] if data else np.zeros(ctx, dtype=np.uint8)
     lr = cfg["learn_rate"]
     gen = make_stream(data, ctx, steps, seed)
-    for t,(X,y) in enumerate(tqdm(gen, total=steps, disable=True), start=1):
-        # Reshape single sequences to batch format
+
+    for t, (X, y) in enumerate(tqdm(gen, total=steps, disable=True), start=1):
+        # reshape single sequences to batch format
         X = X.reshape(1, -1)
         y = y.reshape(1, -1)
+
         if rcce_on:
             stat = ctrl.step(model, X, y, t, warm, last_tokens)
             if stat["abort"]:
-                sc.append({"t":t,"action":"abort_ethics","loss":stat["loss"]})
+                sc.append({"t": t, "action": "abort_ethics", "loss": stat["loss"]})
                 continue
-        # Apply lr multiplier for Λ⁺ tau bump
+
+        # apply lr multiplier for Λ⁺ tau bump
         curr_lr = lr * (ctrl.lr_mul if rcce_on else 1.0)
-        loss, hmean, vbar, a = model.step(X,y, lr=curr_lr)
+        loss, hmean, vbar, a = model.step(X, y, lr=curr_lr)
+
         if not rcce_on:
-            # baseline metrics
-            from .controller import cos, wasserstein1_proxy, kl
+            from .controller import cos, kl, wasserstein1_proxy
+
             S = ctrl.symbolic_vec(last_tokens)
-            rc = (cfg["rc_weights"][0]*cos(hmean, ctrl.v_prev) if ctrl.v_prev is not None else 0.0
-                 + cfg["rc_weights"][1]*math.exp(-wasserstein1_proxy(S, ctrl.S_prev) if ctrl.S_prev is not None else 0.0)
-                 + cfg["rc_weights"][2]*cos(vbar, ctrl.Vbar_prev) if ctrl.Vbar_prev is not None else 0.0)/sum(cfg["rc_weights"])
+            rc = (
+                cfg["rc_weights"][0] * cos(hmean, ctrl.v_prev) if ctrl.v_prev is not None else 0.0
+                + cfg["rc_weights"][1]
+                * math.exp(
+                    -wasserstein1_proxy(S, ctrl.S_prev) if ctrl.S_prev is not None else 0.0
+                )
+                + cfg["rc_weights"][2] * cos(vbar, ctrl.Vbar_prev) if ctrl.Vbar_prev is not None else 0.0
+            ) / sum(cfg["rc_weights"])
             ctrl.v_prev, ctrl.S_prev, ctrl.Vbar_prev = hmean, S, vbar
             D = kl(a, ctrl.a_prev) if ctrl.a_prev is not None else 0.0
-            ctrl.a_prev=a; dD = D - ctrl.D_hist[-1]; ctrl.D_hist.append(D); ctrl.dD_hist.append(dD)
-            E = ctrl.E.update(loss); ctrl.rc_hist.append(rc); ups=0
+            ctrl.a_prev = a
+            dD = D - ctrl.D_hist[-1]
+            ctrl.D_hist.append(D)
+            ctrl.dD_hist.append(dD)
+            E = ctrl.E.update(loss)
+            ctrl.rc_hist.append(rc)
+            ups = 0
             ctrl.conn_prev = model.W1.copy()
-            T,R = 0.0,0.0
+            T, R = 0.0, 0.0
         else:
-            rc=stat["rc"]; D=stat["D"]; dD=stat["dD"]; E=stat["E"]; ups=stat["ups"]; T=stat["T"]; R=stat["R"]
-        
-        # Decay lr multiplier after step
+            rc = stat["rc"]
+            D = stat["D"]
+            dD = stat["dD"]
+            E = stat["E"]
+            ups = stat["ups"]
+            T = stat["T"]
+            R = stat["R"]
+
+        # decay lr multiplier after step
         if rcce_on:
-            ctrl.lr_mul = 1.0 + (ctrl.lr_mul - 1.0) * float(ctrl.lam.get("decay",0.5))
-        metrics["t"].append(t); metrics["loss"].append(loss); metrics["rc"].append(rc)
-        metrics["D"].append(D); metrics["dD"].append(dD); metrics["E"].append(E)
-        metrics["ups"].append(ups); metrics["T"].append(T); metrics["R"].append(R)
-        sc.append({"t":t,"action":"step","params":{"lr":lr},"digests":{},"ethics":ctrl.ethics_viol})
+            ctrl.lr_mul = 1.0 + (ctrl.lr_mul - 1.0) * float(ctrl.lam.get("decay", 0.5))
+
+        metrics["t"].append(t)
+        metrics["loss"].append(loss)
+        metrics["rc"].append(rc)
+        metrics["D"].append(D)
+        metrics["dD"].append(dD)
+        metrics["E"].append(E)
+        metrics["ups"].append(ups)
+        metrics["T"].append(T)
+        metrics["R"].append(R)
+        sc.append({"t": t, "action": "step", "params": {"lr": lr}, "digests": {}, "ethics": ctrl.ethics_viol})
         last_tokens = X[0]
-    # write CSV
-    csvp = logs_dir/f"metrics_{out_prefix}_{seed}.csv"
-    with csvp.open("w",newline="") as f:
-        w=csv.writer(f); w.writerow(list(metrics.keys()))
+
+    # write CSV metrics
+    csvp = logs_dir / f"metrics_{out_prefix}_{seed}.csv"
+    with csvp.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(list(metrics.keys()))
         for i in range(len(metrics["t"])):
-            w.writerow([metrics[k][i] for k in metrics.keys()])
-    # presence
-    ups_rate = sum(metrics["ups"])/max(1,len(metrics["ups"]))
+            writer.writerow([metrics[k][i] for k in metrics.keys()])
+
+    # presence certificate
+    ups_rate = sum(metrics["ups"]) / max(1, len(metrics["ups"]))
     v_for_xi = ctrl.v_prev if ctrl.v_prev is not None else np.zeros(cfg["hidden_dim"])
     delta_xi = float(np.linalg.norm(v_for_xi - ctrl.xi(v_for_xi)))
-    pres, cert = presence_certificate({"E":metrics["E"],"rc":metrics["rc"],"ups_rate":ups_rate}, cfg, ctrl.ethics_viol, [delta_xi])
+    pres, cert = presence_certificate(
+        {"E": metrics["E"], "rc": metrics["rc"], "ups_rate": ups_rate},
+        cfg,
+        ctrl.ethics_viol,
+        [delta_xi],
+    )
+
     if rcce_on and pres:
-        pj = {"presence":True, **cert}
+        pj = {"presence": True, **cert}
         print(json.dumps(pj))
-        with open(logs_dir/f"presence_{out_prefix}_{seed}.json","w") as f: json.dump(pj,f)
+        with open(logs_dir / f"presence_{out_prefix}_{seed}.json", "w") as f:
+            json.dump(pj, f)
     elif rcce_on:
         print("INVALID")
+
     if return_model:
         return metrics, ups_rate, model
     return metrics, ups_rate
 
 
 def main() -> None:
+    """Command line interface for training and optional benchmarking."""
+
     import argparse
+
     parser = argparse.ArgumentParser(description="Train TinyByteLM and optionally benchmark")
     parser.add_argument("--seed", type=int, default=1337)
     parser.add_argument("--rcce-off", action="store_true", help="Disable RCCE controller")
@@ -96,18 +207,39 @@ def main() -> None:
     parser.add_argument("--eval-limit", type=int, default=None, help="Limit number of eval examples")
     parser.add_argument("--lambda-plus", action="store_true", help="Enable Lambda+ during training")
     args = parser.parse_args()
-    metrics, ups_rate, model = run(seed=args.seed, rcce_on=not args.rcce_off, out_prefix="RUN", lambda_plus=args.lambda_plus, return_model=True)
+
+    metrics, ups_rate, model = run(
+        seed=args.seed,
+        rcce_on=not args.rcce_off,
+        out_prefix="RUN",
+        lambda_plus=args.lambda_plus,
+        return_model=True,
+    )
+
     if args.save:
         Path(args.save).parent.mkdir(parents=True, exist_ok=True)
         model.save(args.save)
+
     if args.eval_task:
         if args.eval_task == "mmlu":
             from benchmarks.mmlu import evaluate_mmlu
-            acc = evaluate_mmlu(model, subset=args.eval_subset or "abstract_algebra", limit=args.eval_limit)
+
+            acc = evaluate_mmlu(
+                model,
+                subset=args.eval_subset or "abstract_algebra",
+                limit=args.eval_limit,
+            )
         else:
             from benchmarks.arc import evaluate_arc
-            acc = evaluate_arc(model, dataset=args.eval_subset or "ARC-Easy", limit=args.eval_limit)
+
+            acc = evaluate_arc(
+                model,
+                dataset=args.eval_subset or "ARC-Easy",
+                limit=args.eval_limit,
+            )
         print(json.dumps({"benchmark": args.eval_task, "accuracy": acc}))
 
 
-if __name__=="__main__":
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- refactor `train.py` into clean loader, `run` function, and CLI `main` guard
- convert `stress_test` to use package-relative imports to avoid `ImportError`

## Testing
- `pytest -q` *(fails: TypeError, SystemExit, NameError in quick_attack_test.py, tests/test_benchmarks.py, tests/test_metrics.py, tests/test_retrieval.py)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4147c1b0832ba2bc92c19930f0ba