### PR TITLE
Configure flake8 line length

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120


### PR DESCRIPTION
## Summary
- add flake8 configuration with 120 character line limit

## Testing
- `flake8 tools/legacy/test_complete_transcendence_system.py`
- `pytest` *(fails: ImportError: attempted relative import beyond top-level package)*

------
https://chatgpt.com/codex/tasks/task_e_68bf62cbca7c832bb85514f2928e0e1b

## Summary by Sourcery

Enhancements:
- Add .flake8 config file with max-line-length set to 120